### PR TITLE
[probability bug] bug about objects probability solved

### DIFF
--- a/darknet_ros_3d/darknet_ros_3d/config/darknet_3d.yaml
+++ b/darknet_ros_3d/darknet_ros_3d/config/darknet_3d.yaml
@@ -1,6 +1,7 @@
 darknet_ros_topic: /darknet_ros/bounding_boxes
 output_bbx3d_topic: /darknet_ros_3d/bounding_boxes
-point_cloud_topic: /xtion/depth_registered/points
-working_frame: base_footprint
+point_cloud_topic: /camera/depth_registered/points
+working_frame: camera_link
 mininum_detection_thereshold: 0.3
+minimum_probability: 0.3
 interested_classes: ["person", "italian_biscotti", "smoothie", "mango_juice", "crisps", "water", "sandwich", "toastie", "veggie_pot", "wrap", "espresso", "cappuccino", "americano"]

--- a/darknet_ros_3d/darknet_ros_3d/include/darknet_ros_3d/Darknet3D.h
+++ b/darknet_ros_3d/darknet_ros_3d/include/darknet_ros_3d/Darknet3D.h
@@ -84,7 +84,7 @@ private:
   std::string pointcloud_topic_;
   std::string working_frame_;
   std::vector<std::string> interested_classes_;
-  float mininum_detection_thereshold_;
+  float mininum_detection_thereshold_, minimum_probability_;
 };
 
 };  // namespace darknet_ros_3d

--- a/darknet_ros_3d/darknet_ros_3d/src/darknet_ros_3d/Darknet3D.cpp
+++ b/darknet_ros_3d/darknet_ros_3d/src/darknet_ros_3d/Darknet3D.cpp
@@ -72,12 +72,14 @@ Darknet3D::initParams()
   pointcloud_topic_ = "/camera/depth_registered/points";
   working_frame_ = "/camera_link";
   mininum_detection_thereshold_ = 0.5f;
+  minimum_probability_ = 0.3f;
 
   nh_.param("darknet_ros_topic", input_bbx_topic_, input_bbx_topic_);
   nh_.param("output_bbx3d_topic", output_bbx3d_topic_, output_bbx3d_topic_);
   nh_.param("point_cloud_topic", pointcloud_topic_, pointcloud_topic_);
   nh_.param("working_frame", working_frame_, working_frame_);
   nh_.param("mininum_detection_thereshold", mininum_detection_thereshold_, mininum_detection_thereshold_);
+  nh_.param("minimum_probability", minimum_probability_, minimum_probability_);
   nh_.param("interested_classes", interested_classes_, interested_classes_);
 }
 
@@ -104,7 +106,7 @@ Darknet3D::calculate_boxes(const sensor_msgs::PointCloud2& cloud_pc2,
 
   for (auto bbx : original_bboxes_)
   {
-    if ((bbx.probability < mininum_detection_thereshold_) ||
+    if ((bbx.probability < minimum_probability_) ||
         (std::find(interested_classes_.begin(), interested_classes_.end(), bbx.Class) == interested_classes_.end()))
     {
       continue;


### PR DESCRIPTION
I have added a new parameter to YAML configuration file to specify the minimum probability of objects that darknet_ros provide you want to consider