### PR TITLE
[BUG fixed] 'init_params' method deleted

### DIFF
--- a/darknet_ros_3d/include/darknet_ros_3d/Darknet3D.hpp
+++ b/darknet_ros_3d/include/darknet_ros_3d/Darknet3D.hpp
@@ -53,7 +53,6 @@ private:
   CallbackReturnT on_shutdown(const rclcpp_lifecycle::State & state);
   CallbackReturnT on_error(const rclcpp_lifecycle::State & state);
 
-  void init_params();
   void pointCloudCb(const sensor_msgs::msg::PointCloud2::SharedPtr msg);
   void darknetCb(const darknet_ros_msgs::msg::BoundingBoxes::SharedPtr msg);
   void calculate_boxes(


### PR DESCRIPTION
There was one unused method named *init_params()* defined in *Darknet3D.hpp* so this method header has been deleted